### PR TITLE
Changes in order to be PHP 5.4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 
 php:
+  - 5.4
+  - 5.5
+  - 5.6
   - 7.0
   - 7.1
 
@@ -15,7 +18,7 @@ cache:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 5.4
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at developers(at)uvinum.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $zip_code_validator->validate($a_country_iso_code, $a_zip_code);
 
 ## Change log
 
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+Please see [CHANGELOG](https://github.com/uvinum/zipcode-validator/releases) for more information what has changed recently.
 
 ## Testing
 
@@ -39,11 +39,11 @@ $ composer test
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c63ec426) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/uvinum/zipcode-validator/tags). 
 
 ## Acknowledgments
 
@@ -59,4 +59,4 @@ If you discover any security related issues, please email developers at uvinum.c
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A PHP library that provides zip code validation for many countries.
 
 ## Prerequisites
 
-PHP >= 7.0
+PHP >= 5.4
 
 
 ## Install
@@ -16,7 +16,7 @@ PHP >= 7.0
 Via Composer
 
 ``` bash
-$ composer require uvinum/zipcode-validator
+$ composer require uvinum/zipcodevalidator
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "~4.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0"
+        "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~4.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,20 +44,23 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "^5.0"
     },
     "autoload": {
         "psr-4": {
-            "Uvinum\\": "src"
+            "Uvinum\\ZipCode\\": "src/ZipCode"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Uvinum\\Tests\\": "test"
+            "Uvinum\\Tests\\ZipCode\\": "test/ZipCode"
         }
     },
     "scripts": {
         "test": "phpunit"
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "config": {
+        "optimize-autoloader": true
+    }
 }

--- a/src/ZipCode/Validator.php
+++ b/src/ZipCode/Validator.php
@@ -187,8 +187,6 @@ final class Validator
     ];
 
     /**
-     *
-     *
      * @param string $a_country_iso_code
      * @param string $a_zip_code
      *
@@ -208,8 +206,6 @@ final class Validator
     }
 
     /**
-     *
-     *
      * @param string $a_country_iso_code
      *
      * @return bool
@@ -220,8 +216,6 @@ final class Validator
     }
 
     /**
-     *
-     *
      * @param string $country_iso_code
      *
      * @return array

--- a/src/ZipCode/Validator.php
+++ b/src/ZipCode/Validator.php
@@ -186,7 +186,15 @@ final class Validator
         'ZM' => '\\d{5}',
     ];
 
-    public function validate(string $a_country_iso_code, string $a_zip_code): bool
+    /**
+     *
+     *
+     * @param string $a_country_iso_code
+     * @param string $a_zip_code
+     *
+     * @return bool
+     */
+    public function validate($a_country_iso_code, $a_zip_code)
     {
         if ($this->notHavePatternToValidateZipCodeForThisCountry($a_country_iso_code))
         {
@@ -196,15 +204,29 @@ final class Validator
         }
         $pattern = $this->getPatternToValidateZipCodeForThisCountry($a_country_iso_code);
 
-        return preg_match("/^{$pattern}$/i", $a_zip_code);
+        return (bool) preg_match("/^{$pattern}$/i", $a_zip_code);
     }
 
-    private function notHavePatternToValidateZipCodeForThisCountry(string $a_country_iso_code): bool
+    /**
+     *
+     *
+     * @param string $a_country_iso_code
+     *
+     * @return bool
+     */
+    private function notHavePatternToValidateZipCodeForThisCountry($a_country_iso_code)
     {
         return !array_key_exists($a_country_iso_code, $this->zip_code_patterns_by_country);
     }
 
-    private function getPatternToValidateZipCodeForThisCountry(string $country_iso_code): string
+    /**
+     *
+     *
+     * @param string $country_iso_code
+     *
+     * @return array
+     */
+    private function getPatternToValidateZipCodeForThisCountry($country_iso_code)
     {
         return $this->zip_code_patterns_by_country[$country_iso_code];
     }


### PR DESCRIPTION
Ja tenim els canvis per tal que la nostra flamant lliberia sigui compatible amb versions de PHP a partir de la 5.4.

Feu-hi un cop d'ull que no m'hagi deixat res. Els tests passen sense problemes.

Si tot està ok, canviarem el tag actual d'1.0 a 0.5 "initial version" i no cambiarem a la versió 1.0 "production ready" fins que no el tinguem integrat i funcionant al checkout.

